### PR TITLE
Add '/srcicon.png' to ignored public files list in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -59,6 +59,7 @@ export function middleware(request: NextRequest) {
       '/screenshots/redacted.jpeg',
       '/screenshots/teacherbuddy.png',
       '/screenshots/vet-clinic.png',
+      '/srcicon.png',
     ].includes(pathname)
   ) {
     return;


### PR DESCRIPTION
- Updated the middleware to include '/srcicon.png' in the list of ignored public files.

- This change prevents the middleware from processing requests for the specified icon file, improving performance and resource management.

- No known side effects or limitations.

- Changes were tested in the development environment, ensuring that requests for '/srcicon.png' are correctly ignored without affecting other functionalities.