### PR TITLE
Standardize email terminology in success messages and labels

### DIFF
--- a/dictionaries/de.json
+++ b/dictionaries/de.json
@@ -105,7 +105,7 @@
       "submitLabelAlt": "Senden..."
     },
     "successMessage": "Danke für deine Nachricht! Ich werde mich so schnell wie möglich bei dir melden.",
-    "toastSuccess": "-Mail wurde erfolgreich gesendet!",
+    "toastSuccess": "E-Mail wurde erfolgreich gesendet!",
     "toastError": "Fehler beim Senden der E-Mail. Bitte versuche es später noch einmal.",
     "captchaMissing": "Bitte bestätige, dass du kein Robot bist."
   },

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -96,10 +96,10 @@
       "namePlaceholder": "Enter your name",
       "nameDescription": "Please enter your full name",
       "nameRequired": "Name is required",
-      "emailLabel": "Your Email",
-      "emailPlaceholder": "Enter your email",
-      "emailDescription": "We'll never share your email with anyone else.",
-      "emailRequired": "Email is required",
+      "emailLabel": "Your E-mail",
+      "emailPlaceholder": "Enter your e-mail",
+      "emailDescription": "We'll never share your e-mail with anyone else.",
+      "emailRequired": "E-mail is required",
       "messageLabel": "Your Message",
       "messagePlaceholder": "Enter your message",
       "messageDescription": "Feel free to share feedback, questions, or just say hi!",
@@ -108,8 +108,8 @@
       "submitLabelAlt": "Sending..."
     },
     "successMessage": "Thank you for your message! I'll get back to you as soon as possible.",
-    "toastSuccess": "Email sent successfully!",
-    "toastError": "Error sending email. Please try again later.",
+    "toastSuccess": "E-mail sent successfully!",
+    "toastError": "Error sending e-mail. Please try again later.",
     "captchaMissing": "Please verify that you are not a robot."
   },
   "contactAbout": {


### PR DESCRIPTION
- Updated email-related labels and messages to use "E-mail" instead of "Email" for consistency in both German and English.

- Enhanced user experience by standardizing terminology across the application.

These changes improve clarity and consistency in communication with users. The updates were tested in the application, ensuring that all instances of email terminology reflect the new standard without introducing any errors. No known side effects or limitations were identified.